### PR TITLE
Expand error message when GitHub envvars are not present

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -237,16 +237,20 @@ function run() {
             // available.
             if (createCredentialsFile) {
                 const runnerTempDir = process.env.RUNNER_TEMP;
+                if (!runnerTempDir) {
+                    throw new Error('$RUNNER_TEMP is not set');
+                }
                 // Extract the request token and request URL from the environment. These
                 // are only set when an id-token is requested and the submitter has
                 // collaborator permissions.
                 const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
-                if (!requestToken) {
-                    throw new Error('$ACTIONS_ID_TOKEN_REQUEST_TOKEN is not set');
-                }
                 const requestURLRaw = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
-                if (!requestURLRaw) {
-                    throw new Error('$ACTIONS_ID_TOKEN_REQUEST_URL is not set');
+                if (!requestToken || !requestURLRaw) {
+                    throw new Error('GitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or ' +
+                        '$ACTIONS_ID_TOKEN_REQUEST_URL into this job. This most likely ' +
+                        'means the GitHub Actions workflow permissions are incorrect, or ' +
+                        'this job is being run from a fork. For more information, please ' +
+                        'see the GitHub documentation at https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token');
                 }
                 const requestURL = new url_1.URL(requestURLRaw);
                 // Append the audience value to the request.

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,13 +56,17 @@ async function run(): Promise<void> {
       // are only set when an id-token is requested and the submitter has
       // collaborator permissions.
       const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
-      if (!requestToken) {
-        throw new Error('$ACTIONS_ID_TOKEN_REQUEST_TOKEN is not set');
-      }
       const requestURLRaw = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
-      if (!requestURLRaw) {
-        throw new Error('$ACTIONS_ID_TOKEN_REQUEST_URL is not set');
+      if (!requestToken || !requestURLRaw) {
+        throw new Error(
+          'GitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or ' +
+            '$ACTIONS_ID_TOKEN_REQUEST_URL into this job. This most likely ' +
+            'means the GitHub Actions workflow permissions are incorrect, or ' +
+            'this job is being run from a fork. For more information, please ' +
+            'see the GitHub documentation at https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token',
+        );
       }
+
       const requestURL = new URL(requestURLRaw);
 
       // Append the audience value to the request.


### PR DESCRIPTION
This points people to the GitHub Actions permissions documentation, which will help with troubleshooting token permission errors.

Suggested in https://github.com/google-github-actions/auth/issues/27#issuecomment-935121135