### PR TITLE
chore: Handle non-pull request runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
     - 'main'
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: '${{ github.head_ref || github.base_ref }}'
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
`github.head_ref` is only available in PRs, so the build failed on main