### PR TITLE
docs: fix token format example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Here is a sample GitHub Token for reference for attribute mappings:
   "ref": "refs/heads/master",
   "sha": "d11880f4f451ee35192135525dc974c56a3c1b28",
   "repository": "username/reponame",
-  "repository_owner": "reponame",
+  "repository_owner": "username",
   "run_id": "1238222155",
   "run_number": "18",
   "run_attempt": "1",


### PR DESCRIPTION
A small fix.
I noticed this when using attribute conditions.
`username` is passed to `repository_owner`, not `reponame`.
An example of mapping can also be found in [this GitHub Action documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token).