### PR TITLE
Add workflow to update tag pointer

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,58 @@
+name: 'tag'
+
+on:
+  push:
+    tags:
+    # match vx.y and v x.y.z.w... but not vx
+    - 'v[0-9]+.*'
+
+jobs:
+  # pointer parses the incoming tag value and updates the "vX" pointer to the
+  # same SHA as this tag.
+  pointer:
+    name: 'pointer'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'actions/github-script@v5'
+      with:
+        script: |-
+          const tag = process.env.GITHUB_REF_NAME;
+          if(!tag) {
+            core.setFailed(`Missing tag!`)
+            return
+          }
+          core.info(`Using tag "${tag}"`)
+
+          const matches = tag.match(/(v[0-9]+).*/)
+          if(!matches || matches.length < 2) {
+            core.setFailed(`Invalid tag "${tag}"`)
+            return
+          }
+          const major = matches[1];
+          core.info(`Matched to major tag "${major}"`)
+
+          // Try to update the ref first. If that fails, it probably does not
+          // exist yet, and we should create it.
+          try {
+            await github.rest.git.updateRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${major}`,
+              sha: context.sha,
+              force: true,
+            })
+
+            core.info(`Updated "${major}" to "${tag}" (${context.sha})`)
+          } catch {
+            core.warning(`Failed to update "${major}" tag (it may not `+
+              `exist). Trying to create "${major}" now.`)
+
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${major}`,
+              sha: context.sha,
+            })
+
+            core.info(`Created "${major}" at "${tag}" (${context.sha})`)
+          }


### PR DESCRIPTION
When new tags are pushed, this will automatically create/update a "pointer" tag to the major version as `vMAJOR`. This will allow us to write docs that pin to `@vMAJOR` instead of worrying about pinning to specific MAJOR.MINOR.PATCH.