### PR TITLE
feat: emit a warning when the workspace is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ and permissions on Google Cloud.
     configure a Google Cloud Workload Identity Provider. See [setup](#setup)
     for instructions.
 
+-   You must run the `actions/checkout@v2` step _before_ this action. Omitting
+    the checkout step or putting it after `auth` will cause future steps to be
+    unable to authenticate.
+
 
 ## Usage
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { promises as fs } from 'fs';
+
 /**
  * buildDomainWideDelegationJWT constructs an _unsigned_ JWT to be used for a
  * DWD exchange. The JWT must be signed and then exchanged with the OAuth
@@ -34,4 +36,21 @@ export function buildDomainWideDelegationJWT(
   }
 
   return JSON.stringify(body);
+}
+
+/**
+ * isEmptyDir returns true if the given directory does not exist, or exists but
+ * contains no files. It also returns true if the current user does not have
+ * permission to read the directory, since it is effectively empty from the
+ * viewpoint of the caller.
+ *
+ * @param dir Path to a directory.
+ */
+export async function isEmptyDir(dir: string): Promise<boolean> {
+  try {
+    const files = await fs.readdir(dir);
+    return files.length <= 0;
+  } catch (e) {
+    return true;
+  }
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -3,7 +3,9 @@
 import 'mocha';
 import { expect } from 'chai';
 
-import { buildDomainWideDelegationJWT } from '../src/utils';
+import { tmpdir } from 'os';
+
+import { buildDomainWideDelegationJWT, isEmptyDir } from '../src/utils';
 
 describe('Utils', () => {
   describe('#buildDomainWideDelegationJWT', () => {
@@ -51,6 +53,28 @@ describe('Utils', () => {
         } else {
           expect(body.scope).to.not.be;
         }
+      });
+    });
+  });
+
+  describe('#isEmptyDir', async () => {
+    const cases = [
+      {
+        name: 'non-existent dir',
+        dir: '/this/path/definitely/does/not/exist',
+        exp: true,
+      },
+      {
+        name: 'exists',
+        dir: tmpdir(),
+        exp: false,
+      },
+    ];
+
+    cases.forEach((tc) => {
+      it(tc.name, async () => {
+        const isEmpty = await isEmptyDir(tc.dir);
+        expect(isEmpty).to.eq(tc.exp);
       });
     });
   });


### PR DESCRIPTION
There have been a number of GitHub issues recently due to users not adding actions/checkout before calling "auth", which makes the credentials unavailable to future steps. Worse, some people are putting checkout _after_ auth, which overwrites the generated credentials with a checkout of the repo.

This adds a feature that emits a warning with the workspace is empty.