### PR TITLE
doc: fix registry name example for GAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ jobs:
     # This example uses the docker login action
     - uses: 'docker/login-action@v1'
       with:
-        registry: 'gcr.io' # or REGION.docker.pkg.dev
+        registry: 'gcr.io' # or REGION-docker.pkg.dev
         username: 'oauth2accesstoken'
         password: '${{ steps.auth.outputs.access_token }}'
 


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

Hi, I've added minor fix into readme to use right form GAR registry name.
note: [this line](https://github.com/google-github-actions/auth/blob/main/README.md?plain=1#L325) uses right form.