### PR TITLE
Update actions/checkout to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     - uses: 'actions/setup-node@v2'
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     - uses: 'actions/setup-node@v2'
       with:
@@ -48,7 +48,7 @@ jobs:
         - 'macos-latest'
 
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     - uses: 'actions/setup-node@v2'
       with:
@@ -116,7 +116,7 @@ jobs:
       id-token: 'write'
 
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     - uses: 'actions/setup-node@v2'
       with:
@@ -181,7 +181,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     - uses: 'actions/setup-node@v2'
       with:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and permissions on Google Cloud.
     configure a Google Cloud Workload Identity Provider. See [setup](#setup)
     for instructions.
 
--   You must run the `actions/checkout@v2` step _before_ this action. Omitting
+-   You must run the `actions/checkout@v3` step _before_ this action. Omitting
     the checkout step or putting it after `auth` will cause future steps to be
     unable to authenticate.
 
@@ -60,7 +60,7 @@ jobs:
 
     steps:
     # actions/checkout MUST come before auth
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
@@ -201,7 +201,7 @@ regardless of the authentication mechanism.
      jobs:
       job_id:
         steps:
-        - uses: 'actions/checkout@v2' # Must come first!
+        - uses: 'actions/checkout@v3' # Must come first!
         - uses: 'google-github-actions/auth@v0'
      ```
 
@@ -249,7 +249,7 @@ jobs:
       id-token: 'write'
 
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
@@ -277,7 +277,7 @@ jobs:
     # ...
 
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
@@ -303,7 +303,7 @@ examples:
 jobs:
   job_id:
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
@@ -349,7 +349,7 @@ jobs:
       id-token: 'write'
 
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     # Configure Workload Identity Federation via a credentials file.
     - id: 'auth'
@@ -393,7 +393,7 @@ jobs:
       id-token: 'write'
 
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     # Configure Workload Identity Federation and generate an access token.
     - id: 'auth'
@@ -433,7 +433,7 @@ jobs:
       id-token: 'write'
 
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
     # Configure Workload Identity Federation and generate an access token.
     - id: 'auth'

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -21,7 +21,7 @@ further debug:
 1.  Look at the [debug logs][debug-logs] to see exactly which step is failing.
     Ensure you are using the latest version of that GitHub Action.
 
-1.  Make sure you use `actions/checkout@v2` **before** the `auth` action in your
+1.  Make sure you use `actions/checkout@v3` **before** the `auth` action in your
     workflow.
 
 1.  If the failing action is from `google-github-action/*`, please file an issue


### PR DESCRIPTION
Update actions/checkout to v3.

[actions/checkout](https://github.com/actions/checkout) has been released https://github.com/actions/checkout/releases/tag/v3.0.0.