### PR TITLE
Customize credentials file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ regardless of the authentication mechanism.
         - uses: 'google-github-actions/auth@v0'
      ```
 
+-   `create_credentials_file_name`: (Optional) If set, the action will create
+    a credentials file with the specified name (e.g. 'google-credentials.json').
+    The default is null. This is only available if "create_credentials_file"
+    was set to true.
+
 -   `export_environment_variables`: (Optional) If true, the action will export
     common environment variables which are known to be consumed by popular
     downstream libraries and tools, including:

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,12 @@ inputs:
       used for authentication via gcloud and Google Cloud SDKs.
     default: true
     required: false
+  create_credentials_file_name:
+    description: |-
+      If set, the action will create a credentials file with the specified name
+      (e.g. 'google-credentials.json').
+    default: null
+    required: false
   export_environment_variables:
     description: |-
       If true, the action will export common environment variables which are

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,6 +59,7 @@ async function run(): Promise<void> {
       getInput('audience') || `https://iam.googleapis.com/${workloadIdentityProvider}`;
     const credentialsJSON = getInput('credentials_json');
     const createCredentialsFile = getBooleanInput('create_credentials_file');
+    const createCredentialsFileName = getInput('create_credentials_file_name');
     const exportEnvironmentVariables = getBooleanInput('export_environment_variables');
     const tokenFormat = getInput('token_format');
     const delegates = parseCSV(getInput('delegates'));
@@ -156,7 +157,12 @@ async function run(): Promise<void> {
       }
 
       // Create credentials file.
-      const outputFile = generateCredentialsFilename();
+      var outputFile;
+      if (createCredentialsFileName && createCredentialsFileName.endsWith(".json")) {
+        outputFile = createCredentialsFileName;
+      } else {
+        outputFile = generateCredentialsFilename();
+      }
       const outputPath = pathjoin(githubWorkspace, outputFile);
       const credentialsPath = await client.createCredentialsFile(outputPath);
       logInfo(`Created credentials file at "${credentialsPath}"`);


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

Hello, thanks for this GitHub Action. I am currently using the Service Account Key JSON file approach with a Python application. My app looks for a credentials file specifically named "google-credentials.json".

This Pull Request allows the user of this GitHub Action to optionally customize the name of their google credentials file, so for example I could set mine to "google-credentials.json" instead of generating a random file name.

I am newer to typescript so I haven't run the action or tested it out, but the proposed change should encompass much of the intended design. Let me know if you would like me to make any updates. 

Thanks!
