### PR TITLE
chore: Use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: 'actions/setup-node@v3'
         with:
           node-version: '16.x'
+          cache: 'npm'
 
       - name: 'npm build'
         run: 'npm ci && npm run build'


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated `test.yml` to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Node.js projects can run faster on GitHub Actions by enabling dependency caching on the [setup-node](https://github.com/actions/setup-node) action. 

### AS-IS

```yml
- uses: 'actions/setup-node@v3'
  with:
    node-version: '16'
```

### TO-BE

```yml
- uses: 'actions/setup-node@v3'
  with:
    node-version: '16'
    cache: 'npm'
```

> It’s literally a one line change to pass the `cache: 'npm'` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)