### PR TITLE
260 add permissions example to troubleshooting

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -35,7 +35,7 @@ further debug:
     libraries. Please note that we do not have control over actions outside of
     `google-github-actions`.
 
-If your workflow _fails_ after adding the the step to generate an access token,
+If your workflow _fails_ after adding the step to generate an access token,
 it likely means there is a misconfiguration with Workload Identity. Here are
 some common sources of errors:
 
@@ -54,6 +54,14 @@ some common sources of errors:
 1.  Ensure the `workload_identity_provider` uses the Google Cloud Project
     **number**. Workload Identity Federation does not accept Google Cloud
     Project IDs.
+
+1.  Ensure that you have the correct workflow permissions, per the [usage](../README.md#usage) docs, i.e.
+
+    ```yaml
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    ```
 
 1.  Ensure you have created an **Attribute Mapping** for any **Attribute
     Conditions** or **Service Account Impersonation** principals. You cannot

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -55,7 +55,8 @@ some common sources of errors:
     **number**. Workload Identity Federation does not accept Google Cloud
     Project IDs.
 
-1.  Ensure that you have the correct workflow permissions, per the [usage](../README.md#usage) docs, i.e.
+1.  Ensure that you have the correct `permissions:` for the job in your workflow, per
+    the [usage](../README.md#usage) docs, i.e.
 
     ```yaml
     permissions:


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

Added another case that can cause `auth` to fail, helpful to users on day one of using the tool and trying to understand what's happening.
