### PR TITLE
Update documentation: `token_format` is actually optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ default, this action does not generate any tokens.
     my-service-account@my-project.iam.gserviceaccount.com
     ```
 
--   `token_format`: (Required) This value must be `"access_token"` to generate
+-   `token_format`: (Optional) This value must be `"access_token"` to generate
     OAuth 2.0 access tokens.
 
 -   `access_token_lifetime`: (Optional) Desired lifetime duration of the access


### PR DESCRIPTION
The README documentation is misleading because it states `token_format` is required however [it is not](https://github.com/google-github-actions/auth/blob/main/action.yml#L84-L90)

This caused me some confusion and unnecessary testing because I was configuring `access_token_lifetime` while I didn't have configure `token_format` at all, so any change was completely ignore, because no token was generated.