### PR TITLE
Note .dockerignore in the exclusion for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ support](https://cloud.google.com/support).**
     unable to authenticate.
 
 -   To create binaries, containers, pull requests, or other releases, add the
-    following to your `.gitignore` to prevent accidentially committing
-    credentials to your release artifact:
+    following to your `.gitignore`, `.dockerignore` or similar to prevent
+    accidentally committing credentials to your release artifact:
 
     ```text
     # Ignore generated credentials from google-github-actions/auth

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ support](https://cloud.google.com/support).**
     unable to authenticate.
 
 -   To create binaries, containers, pull requests, or other releases, add the
-    following to your `.gitignore`, `.dockerignore` or similar to prevent
+    following to your `.gitignore`, `.dockerignore` and similar files to prevent
     accidentally committing credentials to your release artifact:
 
     ```text


### PR DESCRIPTION
The README indicates that the ghe-* files should be excluded from git via the .gitignore file. However, from CI, it  is less likely that users will create a new patch back to their version control with the results of their build, but it is more likely that they'll pack it into a container.

This commit clarifies that the container is an equal (or larger) risk and should be excluded. This also works (for example) with Podman.

See:
1. https://docs.docker.com/engine/reference/builder/

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
