### PR TITLE
Don't hide Configuring GitHub authentication... section

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,8 +352,8 @@ information.
 > Service Account. Follow the steps for Workload Identity Federation through a
 > Service Account instead.
 
-<details>
-  <summary>Click here to show detailed instructions for configuring GitHub authentication to Google Cloud via a direct Workload Identity Federation.</summary>
+<a name="direct-wif" id="direct-wif"></a>
+### Configuring GitHub authentication to Google Cloud via direct Workload Identity Federation
 
 These instructions use the [gcloud][gcloud] command-line tool.
 
@@ -456,8 +456,6 @@ These instructions use the [gcloud][gcloud] command-line tool.
     Review the [GitHub documentation][github-oidc] for a complete list of
     options and values. This GitHub repository does not seek to enumerate every
     possible combination.
-</details>
-
 
 <a name="indirect-wif" id="indirect-wif"></a>
 ### Workload Identity Federation through a Service Account


### PR DESCRIPTION
I've been scratching my head over this procedure for ages... and then today I finally spotted that the key information I needed was right here on this page, but because it was hid inside a `<details><summary>` collapsed element I'd never managed to find it before!

I suggest expanding this crucial information into a more visible section, so that people like me don't miss it in the future.