### PR TITLE
Document how to supply multi-value input for access_token_scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ default, this action does not generate any tokens.
 
 -   `access_token_scopes`: (Optional) List of OAuth 2.0 access scopes to be
     included in the generated token. This is only valid when "token_format" is
-    "access_token". The default value is:
+    "access_token". Multiple values should be input as a single comma-separated
+    string. The default value is:
 
     ```text
     https://www.googleapis.com/auth/cloud-platform


### PR DESCRIPTION
Because GitHub Actions has a limitation that YAML arrays cannot be used as inputs (which is a wild choice on their part IMO), different actions each have their own strategy for accepting multi-value inputs. There doesn't seem to be a standard approach, for instance `get-secretmanager-secrets` parses `secrets` as a multi-line input with each secret on a new line, whereas this repo parses list inputs as a single-line comma-separated list.

I found it confusing that the documentation just says "List" and you have to dig into the code to find the `parseCSV` to tell how a multi-value input should be provided for this input.
