### PR TITLE
Security considerations: ids are strings, not integers

### DIFF
--- a/docs/SECURITY_CONSIDERATIONS.md
+++ b/docs/SECURITY_CONSIDERATIONS.md
@@ -40,7 +40,7 @@ curl -sfL -H "Accept: application/json" "https://api.github.com/repos/${REPO}" |
 These can be used in an Attribute Condition:
 
 ```cel
-assertion.repository_owner_id == 1342004 && assertion.repository_id == 260064828
+assertion.repository_owner_id == '1342004' && assertion.repository_id == '260064828'
 ```
 
 [cybersquatting]: https://en.wikipedia.org/wiki/Cybersquatting


### PR DESCRIPTION
Fix doc regarding using assertion on IDs rather than names. They refer to IDs as integers, where those are actually strings, so we need to quote them.

I lost too many hours on this to let anyone else experience the same issue :D