### PR TITLE
fix !project_id error message typo

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -202,7 +202,7 @@ export async function run(logger: Logger) {
     // Set the project ID environment variables to the computed values.
     if (!projectID) {
       logger.info(
-        `⚠️ Failed to a project ID from the given inputs. Neither the ` +
+        `⚠️ Failed to compute a project ID from the given inputs. Neither the ` +
           `"project_id" output nor any environment variables will be ` +
           `exported. If you require these values in other steps, specify the ` +
           `"project_id" input directly.`,


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

Small change! This error message seems like it's missing a word, so based on the comment on line 202, I changed it 
from
> `⚠️ Failed to a project ID from the given inputs.`

to

> `⚠️ Failed to compute a project ID from the given inputs` 


