### PR TITLE
Clarify use of GitHub owner|repository IDs

### DIFF
--- a/docs/SECURITY_CONSIDERATIONS.md
+++ b/docs/SECURITY_CONSIDERATIONS.md
@@ -43,5 +43,7 @@ These can be used in an Attribute Condition:
 assertion.repository_owner_id == '1342004' && assertion.repository_id == '260064828'
 ```
 
+The Attribute Mapping must continue to include `attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner` when using numeric organization and repository ID values. Adding mappings for the ID values (i.e. `attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner,attribute.repository_id=assertion.repository_id,attribute.repository_owner_id=assertion.repository_owner_id`) will work but it is redundant.
+
 [cybersquatting]: https://en.wikipedia.org/wiki/Cybersquatting
 [typosquatting]: https://en.wikipedia.org/wiki/Typosquatting


### PR DESCRIPTION
The documentation explains how to update the Attribute Condition to reflect owner|repository IDs but leaves it to the developer to infer that **no** changes need be made to the Attribute Mapping.

Updates the documentation to be explicit that the mapping is not changed by the use of IDs as conditions.

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
