### PR TITLE
Switch to using /github/home for storing credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,6 @@ support](https://cloud.google.com/support).**
 
 ## Prerequisites
 
--   Run the `actions/checkout@v4` step _before_ this action. Omitting the
-    checkout step or putting it after `auth` will cause future steps to be
-    unable to authenticate.
-
--   To create binaries, containers, pull requests, or other releases, add the
-    following to your `.gitignore`, `.dockerignore` and similar files to prevent
-    accidentally committing credentials to your release artifact:
-
-    ```text
-    # Ignore generated credentials from google-github-actions/auth
-    gha-creds-*.json
-    ```
-
 -   This action runs using Node 20. Use a [runner
     version](https://github.com/actions/virtual-environments) that supports this
     version of Node or newer.
@@ -237,20 +224,8 @@ regardless of the authentication mechanism.
     generate a credentials file which can be used for authentication via gcloud
     and Google Cloud SDKs in other steps in the workflow. The default is true.
 
-    The credentials file is exported into `$GITHUB_WORKSPACE`, which makes it
-    available to all future steps and filesystems (including Docker-based GitHub
-    Actions). The file is automatically removed at the end of the job via a post
-    action. In order to use exported credentials, you **must** add the
-    `actions/checkout` step before calling `auth`. This is due to how GitHub
-    Actions creates `$GITHUB_WORKSPACE`:
-
-     ```yaml
-     jobs:
-      job_id:
-        steps:
-        - uses: 'actions/checkout@v4' # Must come first!
-        - uses: 'google-github-actions/auth@v2'
-     ```
+    The credentials file is exported into the GitHub Actions temp directory,
+    outside of the current workspace.
 
 -   `export_environment_variables`: (Optional) If true, the action will export
     common environment variables which are known to be consumed by popular


### PR DESCRIPTION
The GitHub Action currently puts generated credentials into $GITHUB_WORKSPACE (/github/workspace). Unfortunately this is also the working directory of the checkout, so it's too easy to accidentally bundle the generated credentials into Docker containers, binaries, or anything that uses `*` or `.` as a build context.

In the past, we tried to move the exported credentials into RUNNER_TEMP or other directories, but it always introduced incompatibility with the various community workflows (Docker, self-hosted, etc.):

- https://github.com/google-github-actions/setup-gcloud/pull/148
- https://github.com/google-github-actions/setup-gcloud/pull/149
- https://github.com/google-github-actions/setup-gcloud/pull/405
- https://github.com/google-github-actions/setup-gcloud/pull/412

While undocumented, it appears that `/github/home` is an understood path, AND that path is mounted into Docker containers. That means we can export credentials outside of the workspace and still have them available inside the Docker container without users taking manual actions. This comes at three major costs:

1. ~~We have to write the file into two locations. This isn't ideal, but it's also not the end of the world.~~ Apparently there's some magical path rewriting that GitHub Actions does. If we set the output to the temp path, it gets rewritten into the container.

2. We would be relying on an undocumented filepath which GitHub could change at any point in the future. Since this is not part of the publicly-documented API, GitHub is within their rights to change this without notice, potentially breaking everyone/everything. Here was GitHub's feedback when we asked about the feature:

    > `/github/home` was there for back-compat with non-yaml Actions created 5+ years back, i would not recommend customers to use it.
    > 
    > That folder is not mounted into `service` container since non-yaml Actions didn't have `service` container concept.
    > 
    > We probably don't want to document this legacy info.

3. Because of the previous point, there are no environment variables that export these paths. We have to dynamically compile them, and it's a bit hacky.