### PR TITLE
docs: Update actions/checkout references to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ support](https://cloud.google.com/support).**
 
 ## Prerequisites
 
--   Run the `actions/checkout@v4` step _before_ this action. Omitting the
+-   Run the `actions/checkout@v5` step _before_ this action. Omitting the
     checkout step or putting it after `auth` will cause future steps to be
     unable to authenticate.
 
@@ -58,7 +58,7 @@ jobs:
       id-token: 'write'
 
     steps:
-    - uses: 'actions/checkout@v4'
+    - uses: 'actions/checkout@v5'
 
     - uses: 'google-github-actions/auth@v3'
       with:
@@ -248,7 +248,7 @@ regardless of the authentication mechanism.
      jobs:
       job_id:
         steps:
-        - uses: 'actions/checkout@v4' # Must come first!
+        - uses: 'actions/checkout@v5' # Must come first!
         - uses: 'google-github-actions/auth@v3'
      ```
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -77,7 +77,7 @@ value into a GitHub Secret named 'GOOGLE_CREDENTIALS'.
 jobs:
   job_id:
     steps:
-    - uses: 'actions/checkout@v4'
+    - uses: 'actions/checkout@v5'
 
     - uses: 'google-github-actions/auth@v3'
       with:
@@ -97,7 +97,7 @@ jobs:
       id-token: 'write'
 
     steps:
-    - uses: 'actions/checkout@v4'
+    - uses: 'actions/checkout@v5'
 
     - id: 'auth'
       uses: 'google-github-actions/auth@v3'
@@ -133,7 +133,7 @@ jobs:
       id-token: 'write'
 
     steps:
-    - uses: 'actions/checkout@v4'
+    - uses: 'actions/checkout@v5'
 
     - id: 'auth'
       uses: 'google-github-actions/auth@v3'
@@ -170,7 +170,7 @@ jobs:
       id-token: 'write'
 
     steps:
-    - uses: 'actions/checkout@v4'
+    - uses: 'actions/checkout@v5'
 
     - id: 'auth'
       uses: 'google-github-actions/auth@v3'
@@ -220,7 +220,7 @@ jobs:
       id-token: 'write'
 
     steps:
-    - uses: 'actions/checkout@v4'
+    - uses: 'actions/checkout@v5'
 
     - id: 'auth'
       uses: 'google-github-actions/auth@v3'

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -21,12 +21,12 @@
     to these resources are eventually consistent. Usually they happen
     immediately, but sometimes they can take up to 5 minutes to propagate.
 
-1.  Ensure `actions/checkout@v4` is **before** the `auth` action in your
+1.  Ensure `actions/checkout@v5` is **before** the `auth` action in your
     workflow.
 
     ```yaml
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: 'actions/checkout@v5'
       - uses: 'google-github-actions/auth@v3'
     ```
 


### PR DESCRIPTION
I noticed that actions/checkout is still referenced as v4 and submit this PR to update to v5 according to https://github.com/actions/checkout/releases/tag/v5.0.0

Also there are references in github actions test.yml and publish.yml. If not managed by an automatic dependency update system like dependabot, I could also add an update for the references in the pipeline.
